### PR TITLE
Prevent Zoom on iOS Safari

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -260,6 +260,7 @@ class Game {
 		} else {
 			g.keydowns[39] = true;
 		}
+		event.preventDefault();
 	})
 	window.addEventListener('touchend', function (event) {
 		var clientWidth = document.body.clientWidth;


### PR DESCRIPTION
正常操作游戏区域时，会被系统误判为缩放。使用了 `.preventDefault()` 进行修复